### PR TITLE
Add Travis continuous integration and fix tests so Travis passes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+language: python
+git:
+  depth: 10
+  quiet: true
+python:
+  - "2.7"
+  - "3.6"
+env:
+  matrix:
+    - TF_VERSION="default"
+    - TF_VERSION="tf-nightly"
+install:
+  - ./oss_scripts/oss_pip_install.sh
+script:
+  - ./oss_scripts/oss_tests.sh

--- a/edward2/tensorflow/generated_random_variables.py
+++ b/edward2/tensorflow/generated_random_variables.py
@@ -21,22 +21,46 @@ from __future__ import print_function
 
 import functools
 import inspect
+import re
+import six
 
 from edward2.tensorflow.random_variable import RandomVariable
 from edward2.trace import traceable
 from tensorflow_probability import distributions
-from tensorflow_probability.python.internal import docstring_util
+
+
+def expand_docstring(**kwargs):
+  """Decorator to programmatically expand the docstring.
+
+  Args:
+    **kwargs: Keyword arguments to set. For each key-value pair `k` and `v`,
+      the key is found as `${k}` in the docstring and replaced with `v`.
+
+  Returns:
+    Decorated function.
+  """
+  def _fn_wrapped(fn):
+    """Original function with modified `__doc__` attribute."""
+    doc = inspect.cleandoc(fn.__doc__)
+    for k, v in six.iteritems(kwargs):
+      # Capture each ${k} reference to replace with v.
+      # We wrap the replacement in a function so no backslash escapes
+      # are processed.
+      pattern = r'\$\{' + str(k) + r'\}'
+      doc = re.sub(pattern, lambda match: v, doc)  # pylint: disable=cell-var-from-loop
+    fn.__doc__ = doc
+    return fn
+  return _fn_wrapped
 
 
 def make_random_variable(distribution_cls):
   """Factory function to make random variable given distribution class."""
   @traceable
   @functools.wraps(distribution_cls, assigned=("__module__", "__name__"))
-  @docstring_util.expand_docstring(
-      cls=distribution_cls.__name__,
-      doc=inspect.cleandoc(
-          distribution_cls.__init__.__doc__ if
-          distribution_cls.__init__.__doc__ is not None else ""))
+  @expand_docstring(cls=distribution_cls.__name__,
+                    doc=inspect.cleandoc(
+                        distribution_cls.__init__.__doc__ if
+                        distribution_cls.__init__.__doc__ is not None else ""))
   def func(*args, **kwargs):
     # pylint: disable=g-doc-args
     """Create a random variable for ${cls}.

--- a/edward2/tensorflow/random_variable.py
+++ b/edward2/tensorflow/random_variable.py
@@ -132,7 +132,7 @@ class RandomVariable(object):
     Returns:
       sample_shape: `Tensor`.
     """
-    with tf.compat.v1.name_scope(name):
+    with tf.name_scope(name):
       if isinstance(self._sample_shape, tf.Tensor):
         return self._sample_shape
       return tf.convert_to_tensor(self.sample_shape.as_list(), dtype=tf.int32)

--- a/edward2/tensorflow/random_variable_test.py
+++ b/edward2/tensorflow/random_variable_test.py
@@ -88,7 +88,8 @@ class RandomVariableTest(parameterized.TestCase, tf.test.TestCase):
     if tf.executing_eagerly():
       pattern = "RandomVariable(\"1.234\", shape=(), dtype=float32"
     else:
-      pattern = "RandomVariable(\"Normal\", shape=(), dtype=float32"
+      pattern = "RandomVariable(\"{name}\", shape=(), dtype=float32".format(
+          name=x.distribution.name)
     regexp = re.escape(pattern)
     self.assertRegexpMatches(str(x), regexp)
 
@@ -96,10 +97,11 @@ class RandomVariableTest(parameterized.TestCase, tf.test.TestCase):
   def testRepr(self):
     x = ed.RandomVariable(tfp.distributions.Normal(0.0, 1.0), value=1.234)
     if tf.executing_eagerly():
-      string = ("<ed.RandomVariable 'Normal' shape=() "
-                "dtype=float32 numpy=1.234>")
+      string = ("<ed.RandomVariable '{name}' shape=() "
+                "dtype=float32 numpy=1.234>".format(name=x.distribution.name))
     else:
-      string = "<ed.RandomVariable 'Normal' shape=() dtype=float32>"
+      string = "<ed.RandomVariable '{name}' shape=() dtype=float32>".format(
+          name=x.distribution.name)
     self.assertEqual(repr(x), string)
 
   @tfe.run_test_in_graph_and_eager_modes

--- a/examples/no_u_turn_sampler/__init__.py
+++ b/examples/no_u_turn_sampler/__init__.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from edward2.examples.no_u_turn_sampler.nuts import kernel
+from .nuts import kernel  # local file import
 
 from tensorflow.python.util.all_util import remove_undocumented
 

--- a/examples/no_u_turn_sampler/nuts_test.py
+++ b/examples/no_u_turn_sampler/nuts_test.py
@@ -24,7 +24,6 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-from absl import flags
 from absl.testing import parameterized
 import no_u_turn_sampler  # local file import
 import matplotlib
@@ -35,18 +34,13 @@ import scipy.stats
 import tensorflow.compat.v2 as tf
 import tensorflow_probability as tfp
 
+from tensorflow.python.framework import test_util  # pylint: disable=g-direct-tensorflow-import
+
 tfb = tfp.bijectors
 tfd = tfp.distributions
 
-flags.DEFINE_string("model_dir",
-                    default=os.path.join(os.getenv("TEST_TMPDIR", "/tmp"),
-                                         "test/"),
-                    help="Path to write plots to.")
 
-FLAGS = flags.FLAGS
-
-
-def plot_with_expectation(samples, dist, suffix):
+def plot_with_expectation(samples, dist, model_dir, suffix):
   """Comparison histogram of samples and a line for the expected density."""
   _, bins, _ = plt.hist(samples, bins=30, label="observed")
   bin_width = bins[1] - bins[0]
@@ -56,13 +50,13 @@ def plot_with_expectation(samples, dist, suffix):
   plt.legend()
   ks_stat, pval = scipy.stats.kstest(sorted(samples), dist.cdf)
   plt.title("K-S stat: {}\np-value: {}".format(ks_stat, pval))
-  savefig(suffix)
+  savefig(model_dir, suffix)
   plt.close()
 
 
-def savefig(suffix):
+def savefig(model_dir, suffix):
   """Saves figure given suffix."""
-  filename = os.path.join(FLAGS.model_dir, suffix)
+  filename = os.path.join(model_dir, suffix)
   plt.savefig(filename)
   print("Figure saved in", filename)
 
@@ -71,8 +65,10 @@ class NutsTest(parameterized.TestCase, tf.test.TestCase):
 
   def setUp(self):
     super(NutsTest, self).setUp()
-    tf.io.gfile.makedirs(FLAGS.model_dir)
+    self.model_dir = os.path.join(os.getenv("TEST_TMPDIR", "/tmp"), "test/")
+    tf.io.gfile.makedirs(self.model_dir)
 
+  @test_util.run_v2_only
   def testOneStepFromOrigin(self):
     def target_log_prob_fn(event):
       return tfd.Normal(loc=0., scale=1.).log_prob(event)
@@ -88,9 +84,10 @@ class NutsTest(parameterized.TestCase, tf.test.TestCase):
 
     samples = np.array(samples)
     plt.hist(samples, bins=30)
-    savefig("one_step_from_origin.png")
+    savefig(self.model_dir, "one_step_from_origin.png")
     plt.close()
 
+  @test_util.run_v2_only
   def testReproducibility(self):
     def target_log_prob_fn(event):
       return tfd.Normal(loc=0., scale=1.).log_prob(event)
@@ -110,6 +107,7 @@ class NutsTest(parameterized.TestCase, tf.test.TestCase):
     for x, y in zip(xs, ys):
       self.assertAllEqual(x, y)
 
+  @test_util.run_v2_only
   def testNormal(self):
     def target_log_prob_fn(event):
       return tfd.Normal(loc=0., scale=1.).log_prob(event)
@@ -129,8 +127,10 @@ class NutsTest(parameterized.TestCase, tf.test.TestCase):
     samples = np.array(samples)
     plot_with_expectation(samples,
                           dist=scipy.stats.norm(0, 1),
+                          model_dir=self.model_dir,
                           suffix="one_step_posterior_conservation_normal.png")
 
+  @test_util.run_v2_only
   def testLogitBeta(self):
     def target_log_prob_fn(event):
       return tfd.TransformedDistribution(
@@ -141,7 +141,7 @@ class NutsTest(parameterized.TestCase, tf.test.TestCase):
         distribution=tfd.Beta(concentration0=1.0, concentration1=3.0),
         bijector=tfb.Invert(tfb.Sigmoid())).sample(10, seed=7)
     plt.hist(states.numpy(), bins=30)
-    savefig("logit_beta_start_positions.png")
+    savefig(self.model_dir, "logit_beta_start_positions.png")
     plt.close()
 
     samples = []
@@ -155,11 +155,12 @@ class NutsTest(parameterized.TestCase, tf.test.TestCase):
 
     samples = np.array(samples)
     plt.hist(samples, bins=30)
-    savefig("one_step_logit_beta_posterior_conservation.png")
+    savefig(self.model_dir, "one_step_logit_beta_posterior_conservation.png")
     plt.close()
 
     _ = scipy.stats.ks_2samp(samples.flatten(), states.numpy().flatten())
 
+  @test_util.run_v2_only
   def testMultivariateNormal2d(self):
     def target_log_prob_fn(event):
       return tfd.MultivariateNormalFullCovariance(
@@ -178,15 +179,18 @@ class NutsTest(parameterized.TestCase, tf.test.TestCase):
 
     samples = tf.stack(samples).numpy()
     plt.scatter(samples[:, 0], samples[:, 1])
-    savefig("one_step_posterior_conservation_2d.png")
+    savefig(self.model_dir, "one_step_posterior_conservation_2d.png")
     plt.close()
     plot_with_expectation(samples[:, 0],
                           dist=scipy.stats.norm(0, 1),
+                          model_dir=self.model_dir,
                           suffix="one_step_posterior_conservation_2d_dim_0.png")
     plot_with_expectation(samples[:, 1],
                           dist=scipy.stats.norm(0, 1),
+                          model_dir=self.model_dir,
                           suffix="one_step_posterior_conservation_2d_dim_1.png")
 
+  @test_util.run_v2_only
   def testSkewedMultivariateNormal2d(self):
     def target_log_prob_fn(event):
       return tfd.MultivariateNormalFullCovariance(
@@ -196,7 +200,7 @@ class NutsTest(parameterized.TestCase, tf.test.TestCase):
     rng = np.random.RandomState(seed=7)
     states = tf.cast(rng.normal(scale=[1.0, 10.0], size=[10, 2]), tf.float32)
     plt.scatter(states[:, 0], states[:, 1])
-    savefig("skewed_start_positions_2d.png")
+    savefig(self.model_dir, "skewed_start_positions_2d.png")
     plt.close()
 
     samples = []
@@ -210,21 +214,24 @@ class NutsTest(parameterized.TestCase, tf.test.TestCase):
 
     samples = tf.stack(samples).numpy()
     plt.scatter(samples[:, 0], samples[:, 1])
-    savefig("one_step_skewed_posterior_conservation_2d.png")
+    savefig(self.model_dir, "one_step_skewed_posterior_conservation_2d.png")
     plt.close()
     plot_with_expectation(
         samples[:, 0],
         dist=scipy.stats.norm(0, 1),
+        model_dir=self.model_dir,
         suffix="one_step_skewed_posterior_conservation_2d_dim_0.png")
     plot_with_expectation(
         samples[:, 1],
         dist=scipy.stats.norm(0, 10),
+        model_dir=self.model_dir,
         suffix="one_step_skewed_posterior_conservation_2d_dim_1.png")
 
   @parameterized.parameters(
       (3, 10,),
       (5, 10,),
   )
+  @test_util.run_v2_only
   def testMultivariateNormalNd(self, event_size, num_samples):
     def target_log_prob_fn(event):
       return tfd.MultivariateNormalFullCovariance(
@@ -244,8 +251,9 @@ class NutsTest(parameterized.TestCase, tf.test.TestCase):
 
     samples = np.array(samples)
     plt.scatter(samples[:, 0], samples[:, 1])
-    savefig("projection_chain_{}d_normal_{}_steps.png".format(
-        event_size, num_samples))
+    savefig(self.model_dir,
+            "projection_chain_{}d_normal_{}_steps.png".format( event_size,
+                num_samples))
     plt.close()
 
     target_samples = tfd.MultivariateNormalFullCovariance(
@@ -253,11 +261,11 @@ class NutsTest(parameterized.TestCase, tf.test.TestCase):
         covariance_matrix=tf.eye(event_size)).sample(
             num_samples, seed=4).numpy()
     plt.scatter(target_samples[:, 0], target_samples[:, 1])
-    savefig("projection_independent_{}d_normal_{}_samples.png".format(
-        event_size, num_samples))
+    savefig(self.model_dir,
+            "projection_independent_{}d_normal_{}_samples.png".format(
+                event_size, num_samples))
     plt.close()
 
 
 if __name__ == "__main__":
-  tf.enable_v2_behavior()
   tf.test.main()

--- a/oss_scripts/oss_pip_install.sh
+++ b/oss_scripts/oss_pip_install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Installs Edward2 with various dependencies for unit testing.
 
 set -v  # print commands as they're executed
 set -e  # fail and exit on any command erroring
@@ -7,18 +8,15 @@ set -e  # fail and exit on any command erroring
 
 if [[ "$TF_VERSION" == "tf-nightly"  ]]
 then
-  pip install tf-nightly;
+  pip install tf-nightly
+  pip install tfp-nightly
+  pip install -q -e .[numpy]
 else
-  pip install -q "tensorflow==$TF_VERSION"
+  pip install -q -e .[numpy,tensorflow]
 fi
 
-# Make sure we have the latest version of numpy - avoid problems we were
-# seeing with Python 3
-pip install -q -U numpy
-
-# First ensure that the base dependencies are sufficient for a full import
-pip install -q -e .
+# Ensure that the base dependencies are sufficient for a full import.
 python -c "import edward2 as ed"
 
-# Then install the test dependencies
+# Install test dependencies.
 pip install -q -e .[tests]

--- a/oss_scripts/oss_release.sh
+++ b/oss_scripts/oss_release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Releases a new Edward2 package for Python Package Index.
 
 set -v  # print commands as they're executed
 set -e  # fail and exit on any command erroring

--- a/oss_scripts/oss_tests.sh
+++ b/oss_scripts/oss_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Runs Edward2's unit tests.
 
 set -v  # print commands as they're executed
 
@@ -14,7 +15,7 @@ function set_status() {
     STATUS=$(($last_status || $STATUS))
 }
 
-# Run tests
+# Run tests.
 pytest
 set_status
 

--- a/setup.py
+++ b/setup.py
@@ -32,15 +32,16 @@ setup(
         'six',
     ],
     extras_require={
-        'tensorflow': ['tensorflow>=1.13.0',
-                       'tensorflow-probability>=0.4.0'],
-        'tensorflow_gpu': ['tensorflow-gpu>=1.13.0',
-                           'tensorflow-probability-gpu>=0.4.0'],
+        'tensorflow': ['tensorflow>=1.14.0',
+                       'tensorflow-probability>=0.7.0'],
+        'tensorflow_gpu': ['tensorflow-gpu>=1.14.0',
+                           'tensorflow-probability-gpu>=0.7.0'],
         'numpy': ['numpy>=1.7',
                   'scipy>=1.0.0'],
         'tests': [
-            'absl-py',
-            'pytest',
+            'absl-py>=0.5.0',
+            'matplotlib>=2.0.0',
+            'pytest>=4.0.0',
         ],
     },
     classifiers=[


### PR DESCRIPTION
I made a number of changes so Travis passed:

+ remappings to some TF 2.0 symbols
+ fixed local file imports for the NUTS tests
+ used TF's internal `@run_v2_only` decorator for running certain 2.0 (eager-only) tests
+ removed import to a function TFP doesn't export

Adding a linter is quite a bit of work. Am leaving that for a separate PR.