### PR TITLE
Make constraints.py use the TF2 namespace.

### DIFF
--- a/edward2/tensorflow/constraints.py
+++ b/edward2/tensorflow/constraints.py
@@ -20,7 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import six
-import tensorflow as tf
+import tensorflow.compat.v2 as tf
 
 
 class Positive(tf.keras.constraints.Constraint):


### PR DESCRIPTION
Related: #14.