### PR TITLE
Add pylint to Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ language: python
 git:
   depth: 10
   quiet: true
+stages:
+  - lint
+  - test
+jobs:
+  include:
+    - stage: lint
+      python: "3.6"
+      script: ./oss_scripts/oss_lint.sh
 python:
   - "2.7"
   - "3.6"

--- a/edward2/tensorflow/layers/gaussian_process_test.py
+++ b/edward2/tensorflow/layers/gaussian_process_test.py
@@ -278,7 +278,10 @@ class NeuralProcessTest(tf.test.TestCase):
 
   @test_util.run_v2_only
   def test_call(self):
-    valid_context_x, valid_context_y, valid_target_x, valid_target_y = self.valid_data
+    (valid_context_x,
+     valid_context_y,
+     valid_target_x,
+     valid_target_y) = self.valid_data
     batch_size = valid_context_x.shape[0]
 
     for model in self.models:

--- a/notebooks/Companion.ipynb
+++ b/notebooks/Companion.ipynb
@@ -1329,7 +1329,7 @@
         "    latent_size=latent_size,\n",
         "    data_shape=data_shape,\n",
         "    step_size=[0.1],\n",
-        "    target_log_prob_fn=lambda z: ed.make_log_joint(model)(x=x, z=z)\n",
+        "    target_log_prob_fn=lambda z: ed.make_log_joint(model)(x=x, z=z),\n",
         "    num_transitions=10)\n",
         "alignment = {\"latent_code_posterior\": \"latent_code\"}\n",
         "optimizer = tf.train.AdamOptimizer(1e-2)\n",

--- a/oss_scripts/oss_lint.sh
+++ b/oss_scripts/oss_lint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Runs Python linter.
+
+set -v  # print commands as they're executed
+set -e  # fail and exit on any command erroring
+
+# Run linter.
+rm -rf edward2.egg-info/
+pylint --jobs=2 --rcfile=pylintrc *.py
+pylint --jobs=2 --rcfile=pylintrc */

--- a/oss_scripts/oss_tests.sh
+++ b/oss_scripts/oss_tests.sh
@@ -2,21 +2,7 @@
 # Runs Edward2's unit tests.
 
 set -v  # print commands as they're executed
-
-# Instead of exiting on any failure with "set -e", we'll call set_status after
-# each command and exit $STATUS at the end.
-STATUS=0
-function set_status() {
-    local last_status=$?
-    if [[ $last_status -ne 0 ]]
-    then
-      echo "<<<<<<FAILED>>>>>> Exit code: $last_status"
-    fi
-    STATUS=$(($last_status || $STATUS))
-}
+set -e  # fail and exit on any command erroring
 
 # Run tests.
 pytest
-set_status
-
-exit $STATUS

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,222 @@
+# This is based on Tensor2Tensor's with minor changes (use a diff tool).
+# https://github.com/tensorflow/tensor2tensor/blob/master/pylintrc
+
+[MASTER]
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# Set the cache size for astng objects.
+cache-size=500
+
+# Ignore Py3 files
+ignore=get_references_web.py,get_references_web_single_group.py
+
+
+[REPORTS]
+
+# Set the output format.
+# output-format=sorted-text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Disable the report(s) with the given id(s).
+disable-report=R0001,R0002,R0003,R0004,R0101,R0102,R0201,R0202,R0220,R0401,R0402,R0701,R0801,R0901,R0902,R0903,R0904,R0911,R0912,R0913,R0914,R0915,R0921,R0922,R0923
+
+# Error message template (continued on second line)
+msg-template={msg_id}:{line:3} {obj}: {msg} [{symbol}]
+
+
+[MESSAGES CONTROL]
+# List of checkers and warnings to enable.
+enable=indexing-exception,old-raise-syntax
+
+# List of checkers and warnings to disable.
+disable=abstract-method,access-member-before-definition,arguments-differ,assignment-from-no-return,attribute-defined-outside-init,bad-mcs-classmethod-argument,bad-option-value,c-extension-no-member,consider-merging-isinstance,consider-using-dict-comprehension,consider-using-enumerate,consider-using-in,consider-using-set-comprehension,consider-using-ternary,deprecated-method,design,file-ignored,fixme,global-statement,import-error,inconsistent-return-statements,invalid-unary-operand-type,len-as-condition,locally-disabled,locally-enabled,misplaced-comparison-constant,missing-docstring,multiple-imports,no-else-return,no-member,no-name-in-module,no-self-use,no-value-for-parameter,not-an-iterable,not-context-manager,pointless-except,protected-access,redefined-argument-from-local,signature-differs,similarities,simplifiable-if-expression,star-args,super-init-not-called,suppressed-message,too-many-function-args,trailing-comma-tuple,trailing-newlines,ungrouped-imports,unnecessary-pass,unsubscriptable-object,unused-argument,useless-object-inheritance,useless-return,useless-suppression,wrong-import-order,wrong-import-position
+
+[BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# Regular expression which should only match the name
+# of functions or classes which do not require a docstring.
+no-docstring-rgx=(__.*__|main)
+
+# Min length in lines of a function that requires a docstring.
+docstring-min-length=10
+
+# Regular expression which should only match correct module names. The
+# leading underscore is sanctioned for private modules by Google's style
+# guide.
+#
+# There are exceptions to the basic rule (_?[a-z][a-z0-9_]*) to cover
+# requirements of Python's module system.
+module-rgx=^(_?[a-z][a-z0-9_]*)|__init__$
+
+# Regular expression which should only match correct module level names
+const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression which should only match correct class attribute
+class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression which should only match correct class names
+class-rgx=^_?[A-Z][a-zA-Z0-9]*$
+
+# Regular expression which should only match correct function names.
+# 'camel_case' and 'snake_case' group names are used for consistency of naming
+# styles across functions and methods.
+function-rgx=^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
+
+
+# Regular expression which should only match correct method names.
+# 'camel_case' and 'snake_case' group names are used for consistency of naming
+# styles across functions and methods. 'exempt' indicates a name which is
+# consistent with all naming styles.
+method-rgx=(?x)
+  ^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase
+         |tearDownTestCase|setupSelf|tearDownClass|setUpClass
+         |(test|assert)_*[A-Z0-9][a-zA-Z0-9_]*|next)
+     |(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9_]*)
+     |(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$
+
+
+# Regular expression which should only match correct instance attribute names
+attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
+
+# Regular expression which should only match correct argument names
+argument-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression which should only match correct variable names
+variable-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression which should only match correct list comprehension /
+# generator expression variable names
+inlinevar-rgx=^[a-z][a-z0-9_]*$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=main,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=input,apply,reduce
+
+# List of decorators that define properties, such as abc.abstractproperty.
+property-classes=abc.abstractproperty
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of decorators that create context managers from functions, such as
+# contextlib.contextmanager.
+contextmanager-decorators=contextlib.contextmanager,contextlib2.contextmanager
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching names used for dummy variables (i.e. not used).
+dummy-variables-rgx=^\*{0,2}(_$|unused_|dummy_)
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# "class_" is also a valid for the first argument to a class method.
+valid-classmethod-first-arg=cls,class_
+
+
+[EXCEPTIONS]
+
+overgeneral-exceptions=StandardError,Exception,BaseException
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec,sets
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Regexp for a line that is allowed to be longer than the limit.
+# This "ignore" regex is today composed of several independent parts:
+# (1) Long import lines
+# (2) URLs in comments or pydocs. Detecting URLs by regex is a hard problem and
+#     no amount of tweaking will make a perfect regex AFAICT. This one is a good
+#     compromise.
+# (3) Constant string literals at the start of files don't need to be broken
+#     across lines. Allowing long paths and urls to be on a single
+#     line. Also requires that the string not be a triplequoted string.
+ignore-long-lines=(?x)
+  (^\s*(import|from)\s
+   |^\s*(\#\ )?<?(https?|ftp):\/\/[^\s\/$.?#].[^\s]*>?$
+   |^[a-zA-Z_][a-zA-Z0-9_]*\s*=\s*("[^"]\S+"|'[^']\S+')
+   )
+
+# Maximum number of lines in a module
+max-module-lines=99999
+
+# String used as indentation unit. We differ from PEP8's normal 4 spaces.
+indent-string='  '
+
+# Do not warn about multiple statements on a single line for constructs like
+#   if test: stmt
+single-line-if-stmt=y
+
+# Make sure : in dicts and trailing commas are checked for whitespace.
+no-space-check=
+
+
+[LOGGING]
+
+# Add logging modules.
+logging-modules=logging,absl.logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=
+
+
+# Maximum line length for lambdas
+short-func-length=1
+
+# List of module members that should be marked as deprecated.
+# All of the string functions are listed in 4.1.4 Deprecated string functions
+# in the Python 2.4 docs.
+deprecated-members=string.atof,string.atoi,string.atol,string.capitalize,string.expandtabs,string.find,string.rfind,string.index,string.rindex,string.count,string.lower,string.split,string.rsplit,string.splitfields,string.join,string.joinfields,string.lstrip,string.rstrip,string.strip,string.swapcase,string.translate,string.upper,string.ljust,string.rjust,string.center,string.zfill,string.replace,sys.exitfunc,sys.maxint
+
+
+# List of exceptions that do not need to be mentioned in the Raises section of
+# a docstring.
+ignore-exceptions=AssertionError,NotImplementedError,StopIteration,TypeError
+
+
+# Number of spaces of indent required when the last token on the preceding line
+# is an open (, [, or {.
+indent-after-paren=4

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'tests': [
             'absl-py>=0.5.0',
             'matplotlib>=2.0.0',
+            'pylint>=1.9.0',
             'pytest>=4.0.0',
         ],
     },


### PR DESCRIPTION
Fixes #10.

Note this doesn't run a lint on Jupyter notebooks like Edward1's Travis does. There's a bit more work involved for that, which I'll leave as a todo. We may end up dropping notebooks altogether in favor of a solution like @danijar's Handout.