### PR TITLE
Fix output_shape of DenseBatchEnsemble

### DIFF
--- a/edward2/tensorflow/layers/dense.py
+++ b/edward2/tensorflow/layers/dense.py
@@ -549,7 +549,7 @@ class DenseBatchEnsemble(tf.keras.layers.Layer):
 
     if self.activation is not None:
       outputs = self.activation(outputs)
-    outputs = tf.reshape(outputs, [batch_size, -1])
+    outputs = tf.reshape(outputs, [batch_size, self.units])
     return outputs
 
   def get_config(self):


### PR DESCRIPTION
Before returning output in `DenseBatchEnsemble` we call 

```
outputs = tf.reshape(outputs, [batch_size, -1])
return outputs
```

As a result the `output_shape` is not correctly set when the model is created. This can cause errors if  `DenseBatchEnsemble` is not the last layer. For example, we can't use consecutive `DenseBatchEnsemble` layers:

```
inputs = tf.keras.Input(shape=input_shape)
x = tf.keras.layers.Flatten()(inputs)
x = DenseBatchEnsemble(64, activation='relu')(x)
outputs = DenseBatchEnsemble(10)(x)
model = tf.keras.Model(inputs=inputs, outputs=outputs)
```

Simply setting the shape fixes the issue:
 `outputs = tf.reshape(outputs, [batch_size, self.units])`
