### PR TITLE
Refining in rank1bnns

### DIFF
--- a/experimental/rank1_bnns/cifar.py
+++ b/experimental/rank1_bnns/cifar.py
@@ -26,7 +26,7 @@ import edward2 as ed
 import numpy as np
 from baselines.cifar import utils  # local file import
 from experimental.rank1_bnns import cifar_model  # local file import
-from experimental.rank1_bnns.refining import sample_rank1_auxiliaries
+from experimental.rank1_bnns import refining
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets as tfds
 
@@ -96,7 +96,7 @@ flags.DEFINE_integer('num_eval_samples', 1,
 flags.DEFINE_integer('refining_epochs', 0,
                      'Number of refining epochs. At the default 0 epochs,'
                      'no refining takes place.')
-flags.DEFINE_integer('n_auxiliary_variables', 10, 'Number of auxiliary variables.')
+flags.DEFINE_integer('num_auxiliary_variables', 10, 'Number of auxiliary variables.')
 flags.DEFINE_float('auxiliary_variance_ratio', 0.5,
                    'The variance ratio of each auxiliary variable and the prior.'
                    'The prior variance is reduced by this ratio after sampling each'
@@ -389,11 +389,11 @@ def main(argv):
     logging.info('Starting to run epoch: %s', epoch)
     if epoch in np.linspace(FLAGS.train_epochs,
                             FLAGS.train_epochs + FLAGS.refining_epochs,
-                            FLAGS.n_auxiliary_variables,
+                            FLAGS.num_auxiliary_variables,
                             dtype=int):
-        logging.info('Sampling auxiliary variables with ratio %f',
-                     FLAGS.auxiliary_variance_ratio)
-        sample_rank1_auxiliaries(model, FLAGS.auxiliary_variance_ratio)
+      logging.info('Sampling auxiliary variables with ratio %f',
+                   FLAGS.auxiliary_variance_ratio)
+      refining.sample_rank1_auxiliaries(model, FLAGS.auxiliary_variance_ratio)
 
     for step in range(steps_per_epoch):
       train_step(train_iterator)

--- a/experimental/rank1_bnns/cifar.py
+++ b/experimental/rank1_bnns/cifar.py
@@ -389,7 +389,8 @@ def main(argv):
     logging.info('Starting to run epoch: %s', epoch)
     if epoch in np.linspace(FLAGS.train_epochs,
                             FLAGS.train_epochs + FLAGS.refining_epochs,
-                            FLAGS.n_auxiliary_variables):
+                            FLAGS.n_auxiliary_variables,
+                            dtype=int):
         logging.info('Sampling auxiliary variables with ratio %f',
                      FLAGS.auxiliary_variance_ratio)
         sample_rank1_auxiliaries(model, FLAGS.auxiliary_variance_ratio)

--- a/experimental/rank1_bnns/cifar.py
+++ b/experimental/rank1_bnns/cifar.py
@@ -397,6 +397,7 @@ def main(argv):
 
     for step in range(steps_per_epoch):
       train_step(train_iterator)
+
       current_step = epoch * steps_per_epoch + (step + 1)
       max_steps = steps_per_epoch * (FLAGS.train_epochs + FLAGS.refining_epochs)
       time_elapsed = time.time() - start_time

--- a/experimental/rank1_bnns/refining.py
+++ b/experimental/rank1_bnns/refining.py
@@ -77,11 +77,11 @@ def get_conditional_posterior(posterior_mean,
 
 
 def sample_rank1_auxiliaries(model, auxiliary_var_ratio):
-  """Samples additive Gaussian auxiliary variables for the layer.
+  """Samples additive Gaussian auxiliary variables for the model.
   For every rank1 BNN layer, then it samples additive Gaussian auxiliary
   variables for alpha and gamma. It is assumed that the priors and posteriors
   of alpha and gamma are both Gaussians.
-
+  
   Args:
       model: Keras model.
       auxiliary_var_ratio: The ratio of the variance of the auxiliary variable

--- a/experimental/rank1_bnns/refining.py
+++ b/experimental/rank1_bnns/refining.py
@@ -28,7 +28,7 @@ def get_auxiliary_posterior(posterior_mean,
                             prior_scale,
                             auxiliary_scale):
   """Calculates the posterior of an additive Gaussian auxiliary variable.
-   q(a)=\int p(a|w)q(w)dw.
+  q(a)=\int p(a|w)q(w)dw.
   """
   prior_var = tf.math.pow(prior_scale, 2)
   posterior_var = tf.math.pow(posterior_scale, 2)

--- a/experimental/rank1_bnns/refining.py
+++ b/experimental/rank1_bnns/refining.py
@@ -1,0 +1,22 @@
+# coding=utf-8
+# Copyright 2020 The Edward2 Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Utilities."""
+import edward2 as ed
+import numpy as np
+import tensorflow.compat.v2 as tf
+
+def 

--- a/experimental/rank1_bnns/refining.py
+++ b/experimental/rank1_bnns/refining.py
@@ -14,9 +14,106 @@
 # limitations under the License.
 
 # Lint as: python3
-"""Utilities."""
-import edward2 as ed
+"""Utilities for sampling"""
 import numpy as np
 import tensorflow.compat.v2 as tf
+import tensorflow_probability as tfp
 
-def 
+from experimental.rank1_bnns.rank1_bnn_layers import DenseRank1, Conv2DRank1
+
+
+def get_auxiliary_posterior(posterior_mean,
+                            posterior_scale,
+                            prior_mean,
+                            prior_scale,
+                            auxiliary_scale):
+  """ Calculate the posterior distribution of an additive Gaussian """
+  """ auxiliary variable. q(a)=\int p(a|w)q(w)dw. """
+  prior_var = tf.math.pow(prior_scale, 2)
+  posterior_var = tf.math.pow(posterior_scale, 2)
+  auxiliary_var = tf.math.pow(auxiliary_scale, 2)
+  auxiliary_posterior_mean = (posterior_mean - prior_mean) \
+      * auxiliary_var / prior_var
+  auxiliary_posterior_var = posterior_var * tf.math.pow(auxiliary_var, 2) \
+      / tf.math.pow(prior_var, 2) + auxiliary_var * \
+      (prior_var - auxiliary_var) / prior_var
+  return auxiliary_posterior_mean, tf.sqrt(auxiliary_posterior_var)
+
+
+def get_conditional_prior(prior_mean,
+                          prior_scale,
+                          auxiliary_scale,
+                          auxiliary_sample):
+  """ Calculate the conditional prior given the value of an additive """
+  """ Gaussian auxiliary variable. p(w|a). """
+  prior_var = tf.math.pow(prior_scale, 2)
+  auxiliary_var = tf.math.pow(auxiliary_scale, 2)
+  return prior_mean + auxiliary_sample, tf.sqrt(prior_var - auxiliary_var)
+
+
+def get_conditional_posterior(posterior_mean,
+                              posterior_scale,
+                              prior_mean,
+                              prior_scale,
+                              auxiliary_scale,
+                              auxiliary_sample):
+  """ Calculate the conditional posterior given the value of an additive """
+  """ Gaussian auxiliary variable. q(w|a)\propto p(a|w)q(w). """
+  prior_var = tf.math.pow(prior_scale, 2)
+  posterior_var = tf.math.pow(posterior_scale, 2)
+  auxiliary_var = tf.math.pow(auxiliary_scale, 2)
+  conditional_mean = (prior_mean + (auxiliary_sample * posterior_var *
+                                    prior_var + (posterior_mean - prior_mean)
+                                    * (prior_var - auxiliary_var)
+                                    * prior_var)
+                      / (posterior_var * auxiliary_var + prior_var *
+                         (prior_var - auxiliary_var)))
+  conditional_var = posterior_var * prior_var * (prior_var - auxiliary_var) / \
+                    (auxiliary_var * posterior_var + prior_var *
+                     (prior_var - auxiliary_var))
+  return conditional_mean, tf.sqrt(conditional_var)
+
+
+def sample_rank1_auxiliaries(model, auxiliary_var_ratio):
+  for layer in model.layers:
+    if isinstance(layer, DenseRank1) or isinstance(layer, Conv2DRank1):
+      for rv_name, rv, regularizer in [('alpha', layer.alpha,
+                                        layer.alpha_regularizer),
+                                       ('gamma', layer.gamma,
+                                        layer.gamma_regularizer)]:
+        posterior_mean = rv.distribution.distribution.loc
+        posterior_scale = rv.distribution.distribution.scale
+        prior_mean = regularizer.mean
+        prior_scale = regularizer.stddev
+        auxiliary_scale_ratio = np.sqrt(auxiliary_var_ratio)
+        auxiliary_scale = tf.cast(auxiliary_scale_ratio * prior_scale,
+                                  dtype=posterior_mean.dtype)
+        a_mean, a_scale = get_auxiliary_posterior(posterior_mean,
+                                                  posterior_scale,
+                                                  prior_mean,
+                                                  prior_scale,
+                                                  auxiliary_scale)
+        auxiliary_sample = tfp.distributions.Normal(loc=a_mean,
+                                                    scale=a_scale).sample()
+        new_posterior_mean, new_posterior_scale = get_conditional_posterior(
+            posterior_mean,
+            posterior_scale,
+            prior_mean,
+            prior_scale,
+            auxiliary_scale,
+            auxiliary_sample)
+        new_prior_mean, new_prior_scale = get_conditional_prior(
+            prior_mean,
+            prior_scale,
+            auxiliary_scale,
+            auxiliary_sample)
+        for v in layer.variables:
+          if rv_name + '/mean' in v.name:
+            posterior_mean_variable = v
+            posterior_mean_variable.assign(new_posterior_mean)
+          if rv_name + '/stddev' in v.name:
+            posterior_scale_untransformed = v
+            posterior_scale_untransformed.assign(
+                tfp.math.softplus_inverse(new_posterior_scale))
+          regularizer.mean = new_prior_mean.numpy()
+          regularizer.stddev = new_prior_scale.numpy()


### PR DESCRIPTION
Refining rank1 BNNs.

After the initial training is finished, over the course of the refinement epochs, we sample one ensemble member from each mixture component using refinement. In the refinement process, a few auxiliary variables are sampled at even intervals. The variance of each auxiliary variable is a constant proportion of the remaining prior variance.

It is assumed that the priors and posteriors are Gaussian, and the auxiliary variables are additive Gaussians.

The default value of refining_epochs is 0, so no refining is done by default.

Questions/Notes:
1. Is there a better way of updating the posteriors than finding the corresponding tf variables and assigning them the new values (refining.py line 113)? My impression is that there is not much support for adjusting the parameters of random variables, but I would be interested is there is a more elegant way.
2. I was only able to test for a few epochs on a GPU. We need to check that this code is TPU compatible.
3. We need to see how the optimizer will work with the refinement steps. It might be the case that we need to reset the optimizer state after each refinement.

Suggested experiment to run:
--refining_epochs=50
--n_auxiliary_variables=10
--auxiliary_variance_ratio=0.5

I am also testing the code, but for me it takes about 2 days to train cifar10.