### PR TITLE
Fix AttributeError on unnamed random variables in numpy make_log_joint_fn

### DIFF
--- a/edward2/numpy/program_transformations.py
+++ b/edward2/numpy/program_transformations.py
@@ -111,7 +111,7 @@ def make_log_joint_fn(model):
         rv_name = rv_kwargs.get("name")
         if rv_name is None:
           raise KeyError("Random variable call {} has no name in its arguments."
-                         .format(rv_call.im_class.__name__))
+                         .format(rv_call.__self__.__class__.__name__))
         value = kwargs.get(rv_name)
         if value is None:
           raise LookupError("Keyword argument specifying value for {} is "

--- a/edward2/numpy/program_transformations_test.py
+++ b/edward2/numpy/program_transformations_test.py
@@ -70,6 +70,17 @@ class ProgramTransformationsTest(absltest.TestCase):
     value = log_joint(features, prior_precision, y=y, beta=beta)
     self.assertAlmostEqual(value, true_value)
 
+  def testMakeLogJointUnnamedRandomVariable(self):
+    """Test `make_log_joint` raises a helpful error for unnamed variables."""
+    def normal_model():
+      x = ed.norm.rvs(loc=0., scale=1.)
+      return x
+
+    log_joint = ed.make_log_joint_fn(normal_model)
+
+    with self.assertRaisesRegex(KeyError, 'has no name in its arguments'):
+      log_joint()
+
 if __name__ == '__main__':
   np.random.seed(8327)
   absltest.main()


### PR DESCRIPTION
## Summary

`edward2.numpy.make_log_joint_fn` has a Python 2 leftover in its tracer's error path. When a random variable is called without a `name` keyword argument (and there are no remaining positional arguments to consume), the tracer intends to raise a helpful `KeyError`, but instead references `rv_call.im_class.__name__`. `im_class` was removed in Python 3, so this raises:

```
AttributeError: 'function' object has no attribute 'im_class'
```

which masks the real problem (an unnamed random variable).

## Change

Use `rv_call.__self__.__class__.__name__` instead, which is the same expression the tracer already uses a few lines below to obtain the distribution class. The error message is now:

```
KeyError: 'Random variable call norm_gen has no name in its arguments.'
```

## Test

Added `testMakeLogJointUnnamedRandomVariable` to `edward2/numpy/program_transformations_test.py`, which asserts the `KeyError` (with the expected message) is raised rather than an `AttributeError`.

Verified locally with Python 3.14 / NumPy 2.4 / SciPy 1.18: `python -m pytest edward2/numpy/ -q` passes.